### PR TITLE
Feature/literals

### DIFF
--- a/bonsai/model.py
+++ b/bonsai/model.py
@@ -640,7 +640,7 @@ class CodeLiteral(CodeExpression):
             indent (int): The amount of spaces to use as indentation.
         """
         if self.parenthesis:
-            return '{}({})'.format(' ' * (indent * 4), pretty_str(self.value))
+            return '{}({})'.format(' ' * indent, pretty_str(self.value))
         return pretty_str(self.value, indent=indent)
 
     def __repr__(self):
@@ -721,7 +721,7 @@ class CodeCompositeLiteral(CodeLiteral):
         Kwargs:
             indent (int): The amount of spaces to use as indentation.
         """
-        indent = ' ' * (indent * 4)
+        indent = ' ' * indent
         values = '{{{}}}'.format(', '.join(map(pretty_str, self.value)))
 
         if self.parenthesis:


### PR DESCRIPTION
I added `CodeLiteral` to the bonsai model, to represent literals that cannot be handled by basic Python types.

It comes in handy when describing `None` values, so that Python `None`s  in the parsed files are not mixed with
`None`s in the bonsai AST, with catastrophic outcomes. This has been implemented by the class `CodeNull`.

Another handy use is to describe composite literals, as seen in the class `CodeCompositeLiteral`. While it could be replaced by a plain Python list (an element for each item in the composite literal), its `result` attribute makes for more reusable code in cases where, like Python, more than one type of composite literal exist (tuples, lists, dictionaries...).

It is already used in the branch [davla:feature/py-parser](/davla/bonsai/tree/feature/py-parser)