### PR TITLE
HotFix to extract the correct name of messages and services for the p…

### DIFF
--- a/bonsai/py/py_parser.py
+++ b/bonsai/py/py_parser.py
@@ -193,13 +193,14 @@ class PyAstParser(object):
         node.name = path.basename(path.splitext(file_path)[0])
 
         self.cache[file_path] = (node, imported_names)
-
+        for i in imported_names:
+            self.imported_names_list.append(i)
         return node, imported_names
 
     def __init__(self, pythonpath=None, workspace=''):
         self.global_scope = PyGlobalScope()
         self.file_finder = FileFinder(self, pythonpath, workspace)
-
+        self.imported_names_list = []
         self.cache = {}
 
     def parse(self, file_path):


### PR DESCRIPTION
…ython extractor

With the current version the extractor is not able to find (calling the references resolver) the full messages and services names but this information is available for the parser. With this modification the information can be shared with the extractor