### PR TITLE
Fix interpreting integers with leading 0

### DIFF
--- a/bonsai/cpp/clang_parser.py
+++ b/bonsai/cpp/clang_parser.py
@@ -152,7 +152,10 @@ class CppExpressionBuilder(CppEntityBuilder):
                 token = token.spelling
                 while token.endswith(("U", "u", "L", "l")):
                     token = token[:-1]
-                return int(token, 0), ()
+                try:
+                    return int(token, 0), ()
+                except:
+                    return int(token, 8), ()
             return SomeCpp.INTEGER, ()
 
         if self.cursor.kind == CK.FLOATING_LITERAL:

--- a/bonsai/py/visitor.py
+++ b/bonsai/py/visitor.py
@@ -121,6 +121,7 @@ class BuilderVisitor(ast.NodeVisitor):
             # return to parent
             self.builder.add_child(bonsai_node,
                                    children_builder.imported_names)
+            return bonsai_node, children_scope, props
 
         return builder_visit
 
@@ -355,6 +356,9 @@ class BuilderVisitor(ast.NodeVisitor):
     def visit_Name(self, py_node):
         return self._make_name(py_node, py_node.id)
 
+    def visit_NameConstant(self, py_node):
+        return py_node.value, self.scope, None 
+    
     def visit_NoneAST(self, py_node):
         bonsai_node = py_model.PyNull(self.scope, self.parent)
         return bonsai_node, self.scope, None


### PR DESCRIPTION
When parsing CPP-Integers with a leading zero, the current code throws a ValueError. It seams Python cannot derive the base from such a literal.

Python proof:
`
int("0666", 0)
`
results in:
>Traceback (most recent call last):
  File "<string>", line 1, in <module>
ValueError: invalid literal for int() with base 0: '0666'


CPP example where this error occurs:
`
 const int get_flags = 0666;
`

The pull request will catch the error and assume that its a base 10 integer. Then interpreting works.
