### PR TITLE
fix enum in cpp

### DIFF
--- a/bonsai/model.py
+++ b/bonsai/model.py
@@ -485,6 +485,12 @@ class CodeEnum(CodeEntity):
                     assert isinstance(prev.value, int)
                     codeobj._add(prev.value + 1)
 
+            elif isinstance(codeobj.value, CodeReference):
+                for prev in self.values[:i]:
+                    if isinstance(prev, CodeVariable):
+                        if prev.name == codeobj.value.name:
+                            codeobj._add(prev.value)
+
     def pretty_str(self, indent=0):
         """Return a human-readable string representation of this object.
 


### PR DESCRIPTION
example:
```c++
enum LinkTreeStyle
{
    STYLE_LINK_LIST, // list of all links sorted by link name
    STYLE_DEFAULT = STYLE_LINK_LIST,
    STYLE_JOINT_LIST,     // list of joints sorted by joint name
    STYLE_LINK_TREE,      // tree of links
    STYLE_JOINT_LINK_TREE // tree of joints with links
};
```
See https://github.com/ros-visualization/rviz/blob/noetic-devel/src/rviz/robot/robot.h#L220